### PR TITLE
updated comments for http output mapping param

### DIFF
--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -40,7 +40,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   #
   # For example:
   # [source,ruby]
-  #    mapping => {"foo" => "%{host}" "bar" => "%{type}"]
+  #    mapping => {"foo" => "%{host}" "bar" => "%{type}"}
   config :mapping, :validate => :hash
 
   # Set the format of the http body.

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -40,7 +40,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   #
   # For example:
   # [source,ruby]
-  #    mapping => ["foo", "%{host}", "bar", "%{type}"]
+  #    mapping => {"foo" => "%{host}" "bar" => "%{type}"]
   config :mapping, :validate => :hash
 
   # Set the format of the http body.


### PR DESCRIPTION
mapping param expects a hash but the help example showed an array; corrected the example