### PR TITLE
Migrate to Manticore

### DIFF
--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -53,14 +53,24 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   # Otherwise, the event is sent as json.
   config :format, :validate => ["json", "form", "message"], :default => "json"
 
+  # Number of concurrent requests
+  config :concurrent_requests, :validate => :number, :default => 10
+
   config :message, :validate => :string
 
   public
   def register
-    require "ftw"
+    require "manticore"
     require "uri"
-    @agent = FTW::Agent.new
-    # TODO(sissel): SSL verify mode?
+
+    ssl = Hash.new
+    if @verify_ssl
+      ssl["verify"] = :strict
+    else
+      ssl["verify"] = :disable
+    end
+
+    @client = Manticore::Client.new pool_max: @concurrent_requests, ssl: ssl
 
     if @content_type.nil?
       case @format
@@ -94,43 +104,32 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
       evt = event.to_hash
     end
 
-    case @http_method
-    when "put"
-      request = @agent.put(event.sprintf(@url))
-    when "post"
-      request = @agent.post(event.sprintf(@url))
-    else
-      @logger.error("Unknown verb:", :verb => @http_method)
-    end
-
+    request_headers = Hash.new
     if @headers
       @headers.each do |k,v|
-        request.headers[k] = event.sprintf(v)
+        request_headers = event.sprintf(v)
       end
     end
 
-    request["Content-Type"] = @content_type
+    request_headers["Content-Type"] = @content_type
 
     begin
       if @format == "json"
-        request.body = LogStash::Json.dump(evt)
+        body = LogStash::Json.dump(evt)
       elsif @format == "message"
-        request.body = event.sprintf(@message)
+        body = event.sprintf(@message)
       else
-        request.body = encode(evt)
+        body = encode(evt)
       end
-      #puts "#{request.port} / #{request.protocol}"
-      #puts request
-      #puts
-      #puts request.body
-      response = @agent.execute(request)
+
+      response = @client.http(@http_method, event.sprintf(@url), body: body, headers: request_headers)
 
       # Consume body to let this connection be reused
       rbody = ""
       response.read_body { |c| rbody << c }
       #puts rbody
     rescue Exception => e
-      @logger.warn("Unhandled exception", :request => request, :response => response, :exception => e, :stacktrace => e.backtrace)
+      @logger.warn("Unhandled exception", :request => response.request, :response => response, :exception => e, :stacktrace => e.backtrace)
     end
   end # def receive
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'ftw', ['~> 0.0.40']
+  s.add_runtime_dependency 'manticore', ['~> 0.4.1']
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-http'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Several improvements:
1. Migrate to Manticore.
a) fixes SSL issues
b) much better performance, thanks to connection pools
2. Respect `verify_ssl` configuration.
3. Allow many concurrent respects.
a) Serial round-trip between USA and Europe can kill your day.
b) With multiple concurrent requests, latency is not longer an issue.
c) I'm Ruby noob. It still can be done so much nicer in Java/Scala, but don't know how to do it here.

To give some stats: perf in my quick benchmark grown from 50 -> 2700 lines / second.