### PR TITLE
Http client mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Gemfile.lock
 .bundle
 vendor
+.idea
+*~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+* 1.1.0
+  - Concurrent execution
+  - Add many HTTP options via the http_client mixin
+  - Switch to manticore as HTTP Client

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -135,7 +135,6 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
   # This is split into a separate method mostly to help testing
   def log_failure(message, opts)
-    #puts "FAILED #{message} #{opts}"
     @logger.error("[HTTP Output Failure] #{message}", opts)
   end
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -23,7 +23,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   config :url, :validate => :string, :required => :true
 
   # DEPRECATED. Set 'ssl_certificate_validation' instead
-  config :verify_ssl, :validate => :boolean, :default => true, :deprecated => true
+  config :verify_ssl, :validate => :boolean, :default => true, :deprecated => "Please use 'ssl_certificate_validation' instead. This option will be removed in a future release!"
 
   # The HTTP Verb. One of "put", "post", "patch", "delete", "get", "head"
   config :http_method, :validate => VALID_METHODS, :required => :true

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -10,12 +10,16 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
   VALID_METHODS = ["put", "post", "patch", "delete", "get", "head"]
 
-  # This output lets you `PUT` or `POST` events to a
+  # This output lets you send events to a
   # generic HTTP(S) endpoint
   #
-  # Additionally, you are given the option to customize
-  # the headers sent as well as basic customization of the
-  # event json itself.
+  # This output will execute up to 'pool_max' requests in parallel for performance.
+  # Consider this when tuning this plugin for performance.
+  #
+  # Additionally, note that when parallel execution is used strict ordering of events is not
+  # guaranteed!
+  #
+  # Beware, this gem does not yet support codecs. Please use the 'format' option for now.
 
   config_name "http"
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -45,7 +45,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   #
   # For example:
   # [source,ruby]
-  #    mapping => ["foo", "%{host}", "bar", "%{type}"]
+  #    mapping => {"foo", "%{host}", "bar", "%{type}"}
   config :mapping, :validate => :hash
 
   # Set the format of the http body.
@@ -78,6 +78,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
       case @format
         when "form" ; @content_type = "application/x-www-form-urlencoded"
         when "json" ; @content_type = "application/json"
+        when "message" ; @content_type = "text/plain"
       end
     end
 
@@ -155,7 +156,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     elsif @format == "message"
       event.sprintf(@message)
     else
-      encode(map_event(mapped))
+      encode(map_event(event))
     end
   end
 
@@ -187,9 +188,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     end
   end
 
+  #TODO Extract this to a codec
   def encode(hash)
     return hash.collect do |key, value|
-      CGI.escape(key) + "=" + CGI.escape(value)
+      CGI.escape(key) + "=" + CGI.escape(value.to_s)
     end.join("&")
   end
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-  s.add_runtime_dependency 'logstash-mixin-http_client', '~> 1.0.1'
+  s.add_runtime_dependency 'logstash-mixin-http_client', '>= 1.0.1', '< 2.0.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -25,5 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'
+  s.add_development_dependency 'sinatra'
+  s.add_development_dependency 'webrick'
 end
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-  s.add_runtime_dependency 'logstash-mixin-http_client', '>= 1.0.1', '< 2.0.0'
+  s.add_runtime_dependency 'logstash-mixin-http_client', '~> 1.0.1'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ftw', ['~> 0.0.40']
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-plain'
 end
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
-  s.add_runtime_dependency 'manticore', ['~> 0.4.1']
+  s.add_runtime_dependency 'logstash-mixin-http_client', '>= 1.0.1', '< 2.0.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -1,31 +1,139 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/http"
+require "thread"
+require "sinatra"
+
+PORT = rand(65535-1024) + 1025
 
 class LogStash::Outputs::Http
   attr_writer :agent
+  attr_reader :request_tokens
+end
+
+RSpec.configure do |config|
+  class TestApp < Sinatra::Base
+    def self.multiroute(methods, path, &block)
+      methods.each do |method|
+        method.to_sym
+        self.send method, path, &block
+      end
+    end
+
+
+
+    multiroute(%w(get post put patch delete), "/good") do
+      [200, "YUP"]
+    end
+
+    multiroute(%w(get post put patch delete), "/bad") do
+      [500, "YUP"]
+    end
+  end
+
+  #http://stackoverflow.com/questions/6557079/start-and-call-ruby-http-server-in-the-same-script
+  def sinatra_run_wait(app, opts)
+    queue = Queue.new
+    thread = Thread.new do
+      Thread.abort_on_exception = true
+      app.run!(opts) do |server|
+        queue.push("started")
+      end
+    end
+    queue.pop # blocks until the run! callback runs
+  end
+
+
+  config.before(:suite) do
+    sinatra_run_wait(TestApp, :port => PORT, :server => 'webrick')
+  end
 end
 
 describe LogStash::Outputs::Http do
+  let(:port) { PORT }
   let(:event) { LogStash::Event.new("message" => "hi") }
-  let(:url) { "http://localhost:3131" }
+  let(:url) { "http://localhost:#{port}/good" }
+  let(:method) { "post" }
 
-  before :each do
-    subject.register
+  describe "when num requests > token count" do
+    let(:pool_max) { 10 }
+    let(:num_reqs) { pool_max / 2 }
+    let(:client) { subject.client }
+    subject {
+      LogStash::Outputs::Http.new("url" => url,
+                                  "http_method" => method,
+                                  "pool_max" => pool_max)
+    }
+
+    before do
+      subject.register
+    end
+
+    it "should receive all the requests" do
+      expect(client).to receive(:send).
+                          with(method.to_sym, url, anything).
+                          exactly(num_reqs).times.
+                          and_call_original
+
+      num_reqs.times {|t| subject.receive(event)}
+    end
+  end
+
+  shared_examples("verb behavior") do |method|
+    subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method, "pool_max" => 1) }
+
+    let(:expected_method) { method.clone.to_sym }
+    let(:client) { subject.client }
+
+    before do
+      subject.register
+      allow(client).to receive(:send).
+                         with(expected_method, url, anything).
+                         and_call_original
+      allow(subject).to receive(:log_failure).with(any_args)
+    end
+
+    context "performing a get" do
+      describe "invoking the request" do
+        before do
+          subject.receive(event)
+        end
+
+        it "should execute the request" do
+          expect(client).to have_received(:send).
+                              with(expected_method, url, anything)
+        end
+      end
+
+      context "with passing requests" do
+        before do
+          subject.receive(event)
+        end
+
+        it "should not log a failure" do
+          expect(subject).not_to have_received(:log_failure).with(any_args)
+        end
+      end
+
+      context "with failing requests" do
+        let(:url) { "http://localhost:#{port}/bad"}
+
+        before do
+          subject.receive(event)
+          loop do
+            break if subject.request_tokens.size > 0
+          end
+        end
+
+        it "should log a failure" do
+          expect(subject).to have_received(:log_failure).with(any_args)
+        end
+      end
+    end
   end
 
   LogStash::Outputs::Http::VALID_METHODS.each do |method|
-    subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method) }
-    let(:expected_method) { method.clone }
-    let(:client) { subject.client }
-
-    context "performing a #{method}" do
-      it "should execute the request" do
-        client.stub(url, body: "", code: 200)
-        expect(client).to receive(:send).
-                            with(expected_method, url, anything).
-                            and_call_original
-        subject.receive(event)
-      end
+    context "when using '#{method}'" do
+      include_examples("verb behavior", method)
     end
   end
 end

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -10,26 +10,34 @@ class LogStash::Outputs::Http
   attr_reader :request_tokens
 end
 
-RSpec.configure do |config|
-  class TestApp < Sinatra::Base
-    def self.multiroute(methods, path, &block)
-      methods.each do |method|
-        method.to_sym
-        self.send method, path, &block
-      end
-    end
-
-
-
-    multiroute(%w(get post put patch delete), "/good") do
-      [200, "YUP"]
-    end
-
-    multiroute(%w(get post put patch delete), "/bad") do
-      [500, "YUP"]
+class TestApp < Sinatra::Base
+  def self.multiroute(methods, path, &block)
+    methods.each do |method|
+      method.to_sym
+      self.send method, path, &block
     end
   end
 
+  def self.last_request=(request)
+    @last_request = request
+  end
+
+  def self.last_request
+    @last_request
+  end
+
+  multiroute(%w(get post put patch delete), "/good") do
+    self.class.last_request = request
+    [200, "YUP"]
+  end
+
+  multiroute(%w(get post put patch delete), "/bad") do
+    self.class.last_request = request
+    [500, "YUP"]
+  end
+end
+
+RSpec.configure do |config|
   #http://stackoverflow.com/questions/6557079/start-and-call-ruby-http-server-in-the-same-script
   def sinatra_run_wait(app, opts)
     queue = Queue.new
@@ -49,6 +57,15 @@ RSpec.configure do |config|
 end
 
 describe LogStash::Outputs::Http do
+  # Wait for the async request to finish in this spinlock
+  # Requires pool_max to be 1
+  def wait_for_request
+
+    loop do
+      break if subject.request_tokens.size > 0
+    end
+  end
+
   let(:port) { PORT }
   let(:event) { LogStash::Event.new("message" => "hi") }
   let(:url) { "http://localhost:#{port}/good" }
@@ -119,9 +136,7 @@ describe LogStash::Outputs::Http do
 
         before do
           subject.receive(event)
-          loop do
-            break if subject.request_tokens.size > 0
-          end
+          wait_for_request
         end
 
         it "should log a failure" do
@@ -134,6 +149,84 @@ describe LogStash::Outputs::Http do
   LogStash::Outputs::Http::VALID_METHODS.each do |method|
     context "when using '#{method}'" do
       include_examples("verb behavior", method)
+    end
+  end
+
+  shared_examples("a received event") do
+    before do
+      TestApp.last_request = nil
+    end
+
+    before do
+      subject.receive(event)
+      wait_for_request
+    end
+
+    let(:last_request) { TestApp.last_request }
+    let(:body) { last_request.body.read }
+    let(:content_type) { last_request.env["CONTENT_TYPE"] }
+
+    it "should receive the request" do
+      expect(last_request).to be_truthy
+    end
+
+    it "should receive the event as a hash" do
+      expect(body).to eql(expected_body)
+    end
+
+    it "should have the correct content type" do
+      expect(content_type).to eql(expected_content_type)
+    end
+  end
+
+  describe "integration tests" do
+    let(:url) { "http://localhost:#{port}/good" }
+    let(:event) { LogStash::Event.new("foo" => "bar", "baz" => "bot")}
+
+    subject { LogStash::Outputs::Http.new(config) }
+
+    before do
+      subject.register
+    end
+
+    describe "sending with the default (JSON) config" do
+      let(:config) {
+        {"url" => url, "http_method" => "post", "pool_max" => 1}
+      }
+      let(:expected_body) { LogStash::Json.dump(event) }
+      let(:expected_content_type) { "application/json" }
+
+      include_examples("a received event")
+    end
+
+    describe "sending the event as a form" do
+      let(:config) {
+        {"url" => url, "http_method" => "post", "pool_max" => 1, "format" => "form"}
+      }
+      let(:expected_body) { subject.send(:encode, event.to_hash) }
+      let(:expected_content_type) { "application/x-www-form-urlencoded" }
+
+      include_examples("a received event")
+    end
+
+    describe "sending the event as a message" do
+      let(:config) {
+        {"url" => url, "http_method" => "post", "pool_max" => 1, "format" => "message", "message" => "%{foo} AND %{baz}"}
+      }
+      let(:expected_body) { "#{event["foo"]} AND #{event["baz"]}" }
+      let(:expected_content_type) { "text/plain" }
+
+      include_examples("a received event")
+    end
+
+    describe "sending a mapped event" do
+      let(:config) {
+        {"url" => url, "http_method" => "post", "pool_max" => 1, "mapping" => {"blah" => "X %{foo}"}}
+      }
+      let(:expected_body) { LogStash::Json.dump("blah" => "X #{event["foo"]}") }
+      let(:expected_content_type) { "application/json" }
+
+      include_examples("a received event")
     end
   end
 end

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -1,1 +1,41 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/http"
+require "ftw"
+
+
+class LogStash::Outputs::Http
+  attr_writer :agent
+end
+
+describe LogStash::Outputs::Http do
+  let(:agent) { FTW::Agent.new }
+  let(:event) { LogStash::Event.new("message" => "hi") }
+  let(:url) { "http://localhost:3131" }
+  let(:method) { "post" }
+  subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method) }
+
+  before :each do
+    subject.register
+    subject.agent = agent
+  end
+
+  it "should execute a request" do
+    expect(agent).to receive(:execute).with(FTW::Request)
+    subject.receive(event)
+  end
+
+  context "http_method = post" do
+    it "should execute a POST to a url" do
+      expect(agent).to receive(:post).with(url).and_call_original
+      subject.receive(event)
+    end
+  end
+
+  context "http_method = put" do
+    let(:method) { "put" }
+    it "should execute a PUT to a url" do
+      expect(agent).to receive(:put).with(url).and_call_original
+      subject.receive(event)
+    end
+  end
+end

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -1,41 +1,31 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/http"
-require "ftw"
-
 
 class LogStash::Outputs::Http
   attr_writer :agent
 end
 
 describe LogStash::Outputs::Http do
-  let(:agent) { FTW::Agent.new }
   let(:event) { LogStash::Event.new("message" => "hi") }
   let(:url) { "http://localhost:3131" }
-  let(:method) { "post" }
-  subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method) }
 
   before :each do
     subject.register
-    subject.agent = agent
   end
 
-  it "should execute a request" do
-    expect(agent).to receive(:execute).with(FTW::Request)
-    subject.receive(event)
-  end
+  LogStash::Outputs::Http::VALID_METHODS.each do |method|
+    subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method) }
+    let(:expected_method) { method.clone }
+    let(:client) { subject.client }
 
-  context "http_method = post" do
-    it "should execute a POST to a url" do
-      expect(agent).to receive(:post).with(url).and_call_original
-      subject.receive(event)
-    end
-  end
-
-  context "http_method = put" do
-    let(:method) { "put" }
-    it "should execute a PUT to a url" do
-      expect(agent).to receive(:put).with(url).and_call_original
-      subject.receive(event)
+    context "performing a #{method}" do
+      it "should execute the request" do
+        client.stub(url, body: "", code: 200)
+        expect(client).to receive(:send).
+                            with(expected_method, url, anything).
+                            and_call_original
+        subject.receive(event)
+      end
     end
   end
 end


### PR DESCRIPTION
This merges @jakozaur 's patch #18 and refactors it to use the HttpClient mixin for greater reuse between plugins and fewer dependency issues. It also refactors the method by which concurrency is implemented to achieve greater thread liveness.

Additionally this merges in @jsvd 's specs patches and adds to them.

Tests in this patch use a real HTTP server due to issues with manticore's mocking capabilities.