### PR TITLE
race condition with async request handlers and specs robustness & logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 2.0.3
+ - fixed potential race condition on async callbacks
+ - silenced specs equest logs and other spec robustness fixes
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -90,8 +90,6 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   end # def register
 
   def receive(event)
-    
-
     body = event_body(event)
 
     # Block waiting for a token
@@ -104,11 +102,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     # Create an async request
     request = client.send(@http_method, url, body: body, headers: headers, async: true)
 
-    # Invoke it using the Manticore Executor (CachedThreadPool) directly
-    request_async_background(request)
+    # attach handlers before performing request
 
-    # Make sure we return the token to the pool
     request.on_complete do
+      # Make sure we return the token to the pool
       @request_tokens << token
     end
 
@@ -133,6 +130,9 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
                   :backtrace => exception.backtrace
       )
     end
+
+    # Invoke it using the Manticore Executor (CachedThreadPool) directly
+    request_async_background(request)
   end
 
   private

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-http'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -10,7 +10,19 @@ class LogStash::Outputs::Http
   attr_reader :request_tokens
 end
 
+# note that Sinatra startup and shutdown messages are directly logged to stderr so
+# it is not really possible to disable them without reopening stderr which is not advisable.
+#
+# == Sinatra (v1.4.6) has taken the stage on 51572 for development with backup from WEBrick
+# == Sinatra has ended his set (crowd applauds)
+
 class TestApp < Sinatra::Base
+
+  # disable WEBrick logging
+  def self.server_settings
+    { :AccessLog => [], :Logger => WEBrick::BasicLog::new(nil, WEBrick::BasicLog::FATAL) }
+  end
+
   def self.multiroute(methods, path, &block)
     methods.each do |method|
       method.to_sym
@@ -41,15 +53,19 @@ RSpec.configure do |config|
   #http://stackoverflow.com/questions/6557079/start-and-call-ruby-http-server-in-the-same-script
   def sinatra_run_wait(app, opts)
     queue = Queue.new
-    thread = Thread.new do
-      Thread.abort_on_exception = true
-      app.run!(opts) do |server|
-        queue.push("started")
+
+    Thread.new(queue) do |queue|
+      begin
+        app.run!(opts) do |server|
+          queue.push("started")
+        end
+      rescue
+        # ignore
       end
     end
+
     queue.pop # blocks until the run! callback runs
   end
-
 
   config.before(:suite) do
     sinatra_run_wait(TestApp, :port => PORT, :server => 'webrick')
@@ -62,6 +78,7 @@ describe LogStash::Outputs::Http do
   def wait_for_request
 
     loop do
+      sleep(0.1)
       break if subject.request_tokens.size > 0
     end
   end


### PR DESCRIPTION
- fixed potential race condition on async callbacks; callback are now attached **before** the request is launched
- silenced request logging in specs
- added robustness in spec thread etc