### PR TITLE
fix/memleak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - fixed memory leak
+
 ## 2.0.3
  - fixed potential race condition on async callbacks
  - silenced specs equest logs and other spec robustness fixes

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -100,7 +100,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     headers = event_headers(event)
 
     # Create an async request
-    request = client.send(@http_method, url, body: body, headers: headers, async: true)
+    request = client.send(@http_method, url, :body => body, :headers => headers, :async_background => true)
 
     # attach handlers before performing request
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -89,6 +89,8 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     validate_format!
   end # def register
 
+  # TODO: (colin) the request call sequence + async handling will have to be reworked when using
+  # Maticore >= 5.0. I will set a version constrain in the gemspec for this.
   def receive(event)
     body = event_body(event)
 
@@ -100,7 +102,12 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     headers = event_headers(event)
 
     # Create an async request
-    request = client.send(@http_method, url, :body => body, :headers => headers, :async_background => true)
+    request = client.send(@http_method, url, :body => body, :headers => headers, :async => true)
+
+    # with Maticore version < 0.5 using :async => true places the requests in an @async_requests
+    # list which is used & cleaned by Client#execute! but we are not using it here and we must
+    # purge it manually to avoid leaking requests.
+    client.clear_pending
 
     # attach handlers before performing request
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.0.2", "< 3.0.0"
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'logstash-codec-plain'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'webrick'
 end

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
   s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.0.2", "< 3.0.0"
 
+  # Constrain Maticore dependency to less than 0.5.0 because of changes in the async handling
+  # see note in http.rb line 92-93
+  s.add_runtime_dependency "manticore", "< 0.5.0"
+
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'webrick'

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-http'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
fixes #24 

this fixes a memory leak resulting from the "partial" usage of the Manticore Client class, we are handling manually the async execution of the requests, bypassing the pending request book keeping and thus leaking Response objects if not explicitly clearing as done with this PR.

Note that this fix and the async request handling in the plugin is compatible with Manticore versions < 0.5.0 so I also added a version constrain in the gemspec.

I have tested these scenarios for long enough and verified the heap usage signature to verify that there is no more leak:
- tested against an http server sending 200 responses
- tested against an http server serving 200 and 500 responses
- tested against an http server serving 200 and 500 responses and stopping and restarting the server every second to generate invalid requests
