### PR TITLE
Proper client close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+- jruby-1.7.22
+script: bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+ - Properly close the client on #close
+ - Optimized execution for Logstash 2.2 ng pipeline
+
 ## 2.0.5
  - fixed memory leak
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Logstash Plugin
 
-[![Build
-Status](http://build-eu-00.elastic.co/view/LS%20Plugins/view/LS%20Outputs/job/logstash-plugin-output-http-unit/badge/icon)](http://build-eu-00.elastic.co/view/LS%20Plugins/view/LS%20Outputs/job/logstash-plugin-output-http-unit/)
+[![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-output-http.svg)](https://travis-ci.org/logstash-plugins/logstash-output-http)
 
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-http'
-  s.version         = '2.0.5'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -20,12 +20,8 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.0.2", "< 3.0.0"
-
-  # Constrain Maticore dependency to less than 0.5.0 because of changes in the async handling
-  # see note in http.rb line 92-93
-  s.add_runtime_dependency "manticore", "< 0.5.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.0", "< 3.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -119,15 +119,15 @@ describe LogStash::Outputs::Http do
     end
   end
 
-  shared_examples("verb behavior") do |method, proxy_method|
+  shared_examples("verb behavior") do |method, async_type|
     subject { LogStash::Outputs::Http.new("url" => url, "http_method" => method, "pool_max" => 1) }
 
     let(:expected_method) { method.clone.to_sym }
     let(:client) { subject.client }
-    let(:client_proxy) { subject.client.send(proxy_method) }
+    let(:client_proxy) { subject.client.send(async_type) }
 
     before do
-      allow(client).to receive(proxy_method).and_return(client_proxy)
+      allow(client).to receive(async_type).and_return(client_proxy)
       subject.register
       allow(client_proxy).to receive(:send).
                          with(expected_method, url, anything).
@@ -138,7 +138,7 @@ describe LogStash::Outputs::Http do
     context "performing a get" do
       describe "invoking the request" do
         before do
-          subject.receive(event, proxy_method)
+          subject.receive(event, async_type)
         end
 
         it "should execute the request" do
@@ -161,9 +161,9 @@ describe LogStash::Outputs::Http do
         let(:url) { "http://localhost:#{port}/bad"}
 
         before do
-          subject.receive(event, proxy_method)
+          subject.receive(event, async_type)
 
-          if proxy_method == :background
+          if async_type == :background
             wait_for_request
           else
             subject.client.execute!


### PR DESCRIPTION
This properly closes connections on shutdown as well as prepping this plugin for the ng_pipeline by defining a `multi_receive` method.