### PR TITLE
Logging fixes

### DIFF
--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -124,7 +124,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     request.on_success do |response|
       if response.code < 200 || response.code > 299
         log_failure(
-          "Encountered non-200 HTTP code #{200}",
+          "Encountered non-200 HTTP code #{response.code}",
           :response_code => response.code,
           :url => url,
           :event => event)

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -127,7 +127,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
           "Encountered non-200 HTTP code #{response.code}",
           :response_code => response.code,
           :url => url,
-          :event => event)
+          :event => event.to_hash)
       end
     end
 


### PR DESCRIPTION
I noticed that logging the entire event object results in very large log lines when failed request rate is high, combined with large events.

I assume this happens because `LogStash::Event` has multiple references to the event data.