### PR TITLE
feat/mapping: allow nested hash

### DIFF
--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -46,7 +46,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   #
   # For example:
   # [source,ruby]
-  #    mapping => {"foo" => "%{host}" 
+  #    mapping => {"foo" => "%{host}"
   #               "bar" => "%{type}"}
   config :mapping, :validate => :hash
 
@@ -174,11 +174,27 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     end
   end
 
+  def reduce_hash(hash, event)
+    hash.reduce({}) do |acc, kv|
+      k, v = kv
+      if v.is_a?(Hash)
+        acc[k] = reduce_hash(v, event)
+      else
+        acc[k] = event.sprintf(v)
+      end
+      acc
+    end
+  end
+
   def map_event(event)
     if @mapping
       @mapping.reduce({}) do |acc,kv|
         k,v = kv
-        acc[k] = event.sprintf(v)
+        if v.is_a?(Hash)
+          acc[k] = reduce_hash(v, event)
+        else
+          acc[k] = event.sprintf(v)
+        end
         acc
       end
     else

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -84,7 +84,9 @@ describe LogStash::Outputs::Http do
   end
 
   let(:port) { PORT }
-  let(:event) { LogStash::Event.new("message" => "hi") }
+  let(:event) {
+    LogStash::Event.new({"message" => "hi"})
+  }
   let(:url) { "http://localhost:#{port}/good" }
   let(:method) { "post" }
 
@@ -216,7 +218,9 @@ describe LogStash::Outputs::Http do
 
   describe "integration tests" do
     let(:url) { "http://localhost:#{port}/good" }
-    let(:event) { LogStash::Event.new("foo" => "bar", "baz" => "bot")}
+    let(:event) {
+      LogStash::Event.new("foo" => "bar", "baz" => "bot", "user" => "McBest")
+    }
 
     subject { LogStash::Outputs::Http.new(config) }
 
@@ -256,9 +260,36 @@ describe LogStash::Outputs::Http do
 
     describe "sending a mapped event" do
       let(:config) {
-        {"url" => url, "http_method" => "post", "pool_max" => 1, "mapping" => {"blah" => "X %{foo}"}}
+        {"url" => url, "http_method" => "post", "pool_max" => 1, "mapping" => {"blah" => "X %{foo}"} }
       }
       let(:expected_body) { LogStash::Json.dump("blah" => "X #{event.get("foo")}") }
+      let(:expected_content_type) { "application/json" }
+
+      include_examples("a received event")
+    end
+
+    describe "sending a mapped, nested event" do
+      let(:config) {
+        {
+          "url" => url,
+          "http_method" => "post",
+          "pool_max" => 1,
+          "mapping" => {
+            "host" => "X %{foo}",
+            "event" => {
+              "user" => "Y %{user}"
+            }
+          }
+        }
+      }
+      let(:expected_body) {
+        LogStash::Json.dump({
+          "host" => "X #{event.get("foo")}",
+          "event" => {
+            "user" => "Y #{event.get("user")}"
+          }
+        })
+      }
       let(:expected_content_type) { "application/json" }
 
       include_examples("a received event")


### PR DESCRIPTION
this PR adds support for nested hashes in mapping, like this: 

```
output {
    http {
      url => "http://localhost:8997"
      http_method => "post"

      mapping => {
        "time" => "%{@timestamp}"
        "host" => "%{host}"
        "source" => "%{image_name}"
        "sourcetype" => "log"
        "index" => "any-index"
        "event" => {
          "message" => "%{message}"
          "severity" => "%{loglevel}"
        }
      }
    }
}
```
