### PR TITLE
Allow nested array in mapping

### DIFF
--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -287,7 +287,10 @@ describe LogStash::Outputs::Http do
             "host" => "X %{foo}",
             "event" => {
               "user" => "Y %{user}"
-            }
+            },
+            "arrayevent" => [{
+              "user" => "Z %{user}"
+            }]
           }
         }
       }
@@ -296,7 +299,10 @@ describe LogStash::Outputs::Http do
           "host" => "X #{event.get("foo")}",
           "event" => {
             "user" => "Y #{event.get("user")}"
-          }
+          },
+          "arrayevent" => [{
+            "user" => "Z #{event.get("user")}"
+          }]
         })
       }
       let(:expected_content_type) { "application/json" }


### PR DESCRIPTION
This PR adds support for nested arrays in mapping, like this:
```
output {
    http {
      url => "https://hooks.slack.com/xxxxxx"
      http_method => "post"

      mapping => {
        "host" => "%{host}"
        "attachments" => [
          {
            "title" => "%{title}"
            "text" => "%{text}"
          }
        ]
      }
    }
}
```

While slack incomming-webhook is using nested array, the feature allows to use the enhanced feature in slack webhook: https://api.slack.com/docs/message-attachments