### PR TITLE
Correct the gem name in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can use the same **2.1** method to run your plugin in an installed Logstash 
 
 - Build your plugin gem
 ```sh
-gem build logstash-filter-awesome.gemspec
+gem build logstash-output-http.gemspec
 ```
 - Install the plugin from the Logstash home
 ```sh


### PR DESCRIPTION
Hello, 

I've changed one line in the readme that specifies that is responsible for building the gem. 
There was an outdated name out there. 

Thanks, 
Vadim 
