### PR TITLE
Fix async calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+ - Fix deadlock that could occur in certain odd situations. If you noticed this plugin stalling this should fix it.
+
 ## 4.3.0
  - Add `user` and `password` options to support HTTP basic auth
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.3.1
- - Fix deadlock that could occur in certain odd situations. If you noticed this plugin stalling this should fix it.
+ - Fix deadlock that could occur in certain situations. All users should upgrade to the latest version.
+   This deadlock was caused by certain async HTTP APIs being called out of order thus creating a race.
 
 ## 4.3.0
  - Add `user` and `password` options to support HTTP basic auth

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -198,7 +198,6 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
     # Create an async request
     request = client.background.send(@http_method, url, :body => body, :headers => headers)
-    request.call # Actually invoke the request in the background
 
     request.on_success do |response|
       begin
@@ -256,6 +255,8 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
           :backtrace => e.backtrace)
         end
     end
+
+    request.call # Actually invoke the request in the background
   end
 
   def close

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -256,7 +256,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
         end
     end
 
-    request.call # Actually invoke the request in the background
+    # Actually invoke the request in the background
+    # Note: this must only be invoked after all handlers are defined, otherwise
+    # those handlers are not guaranteed to be called!
+    request.call 
   end
 
   def close

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -285,15 +285,6 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     @logger.error("[HTTP Output Failure] #{message}", opts)
   end
 
-  # Manticore doesn't provide a way to attach handlers to background or async requests well
-  # It wants you to use futures. The #async method kinda works but expects single thread batches
-  # and background only returns futures.
-  # Proposed fix to manticore here: https://github.com/cheald/manticore/issues/32
-  def request_async_background(request)
-    @method ||= client.executor.java_method(:submit, [java.util.concurrent.Callable.java_class])
-    @method.call(request)
-  end
-
   # Format the HTTP body
   def event_body(event)
     # TODO: Create an HTTP post data codec, use that here

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '4.3.1'
+  s.version         = '4.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes https://github.com/elastic/logstash/issues/7588#issuecomment-313064548 by correctly ordering calls to manticore.

Also removes a dead function that used to be the thing that sent requests.