### PR TITLE
bump version on http_client mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.0
+ - Breaking: bump dependency in breaking version of logstash-mixin-http_client
+
 ## 4.3.3
  - Docs: Add plugin description.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -64,7 +64,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-retryable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_validation>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|No
@@ -317,15 +316,6 @@ If encountered as response codes this plugin will retry these requests
   * Default value is `10`
 
 Timeout (in seconds) to wait for data on the socket. Default is `10s`
-
-[id="plugins-{type}s-{plugin}-ssl_certificate_validation"]
-===== `ssl_certificate_validation` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-Set this to false to disable SSL/TLS certificate validation
-Note: setting this to false is generally considered insecure!
 
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore` 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '4.3.3'
+  s.version         = '5.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 5.1.0", "< 6.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 6.0.0", "< 7.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'


### PR DESCRIPTION
the http_client mixin gem has been bumped a major version to make `ssl_certificate_verification` obsolete, so we need to bump this version a major version that depends on it.