### PR TITLE
include automatic_retries check before retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.1
+ - Fix using automatic_retries
+
 ## 5.0.0
  - Breaking: bump dependency in breaking version of logstash-mixin-http_client
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -163,6 +163,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
             if successes.get+failures.get == events.size
               pending << :done
             end
+
+            if retries.get == @automatic_retries.to_i
+              pending << :done
+            end
           end
         rescue => e 
           # This should never happen unless there's a flat out bug in the code

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -234,7 +234,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
     request.on_failure do |exception|
       begin 
-        will_retry = retryable_exception?(exception)
+        will_retry = attempt < @automatic_retries && retryable_exception?(exception)
         log_failure("Could not fetch URL",
                     :url => url,
                     :method => @http_method,

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -164,7 +164,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
               pending << :done
             end
 
-            if retries.get == @automatic_retries.to_i
+            if retries.get >= @automatic_retries.to_i
               pending << :done
             end
           end

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.0.0'
+  s.version         = '5.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
It seems nothing in the chain output-http -> mixin -> manticore -> apache http client check to stop retries with the automatic_retries config, so retries continue endlessly