### PR TITLE
Adding tests for HTTP_COMPRESSION => true

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,6 +48,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-format>> |<<string,string>>, one of `["json", "form", "message"]`|No
 | <<plugins-{type}s-{plugin}-headers>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-http_compression>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-http_method>> |<<string,string>>, one of `["put", "post", "patch", "delete", "get", "head"]`|Yes
 | <<plugins-{type}s-{plugin}-ignorable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
@@ -171,6 +172,15 @@ Otherwise, the event is sent as json.
 
 Custom headers to use
 format is `headers => ["X-My-Header", "%{host}"]`
+
+[id="plugins-{type}s-{plugin}-http_compression"]
+===== `http_compression`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enable request compression support. With this enabled the plugin will compress
+http requests using gzip.
 
 [id="plugins-{type}s-{plugin}-http_method"]
 ===== `http_method` 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -81,8 +81,8 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   # Otherwise, the event is sent as json.
   config :format, :validate => ["json", "form", "message"], :default => "json"
 
-  # Set this to true if you want to enable gzip compression for your message
-  config :compression, :validate => :boolean
+  # Set this to true if you want to enable gzip compression for your http requests
+  config :http_compression, :validate => :boolean, :default => false
   
   config :message, :validate => :string
 
@@ -201,7 +201,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     headers = event_headers(event)
 
     # Compress the body and add appropriate header
-    if @compression == true
+    if @http_compression == true
       headers["Content-Encoding"] = "gzip"
       body = gzip(body)
     end

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -313,6 +313,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   # gzip data
   def gzip(data)
     gz = StringIO.new
+    gz.set_encoding("BINARY")
     z = Zlib::GzipWriter.new(gz)
     z.write(data)
     z.close

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -4,6 +4,7 @@ require "logstash/namespace"
 require "logstash/json"
 require "uri"
 require "logstash/plugin_mixins/http_client"
+require "zlib"
 
 class LogStash::Outputs::Http < LogStash::Outputs::Base
   include LogStash::PluginMixins::HttpClient
@@ -80,6 +81,9 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   # Otherwise, the event is sent as json.
   config :format, :validate => ["json", "form", "message"], :default => "json"
 
+  # Set this to true if you want to enable gzip compression for your message
+  config :compression, :validate => :boolean
+  
   config :message, :validate => :string
 
   def register
@@ -196,6 +200,12 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     url = event.sprintf(@url)
     headers = event_headers(event)
 
+    # Compress the body and add appropriate header
+    if @compression == true
+      headers["Content-Encoding"] = "gzip"
+      body = gzip(body)
+    end
+
     # Create an async request
     request = client.background.send(@http_method, url, :body => body, :headers => headers)
 
@@ -298,6 +308,15 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     else
       encode(map_event(event))
     end
+  end
+
+  # gzip data
+  def gzip(data)
+    gz = StringIO.new
+    z = Zlib::GzipWriter.new(gz)
+    z.write(data)
+    z.close
+    gz.string
   end
 
   def convert_mapping(mapping, event)

--- a/spec/supports/compressed_requests.rb
+++ b/spec/supports/compressed_requests.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+#
+# based on relistan's rack handler
+# out of the box rack only gives use the rack deflater handler to return compressed
+# response, this gist offer the inverse and should work on all rack based app like sinatra or rails.
+#
+# original source: https://gist.github.com/relistan/2109707
+require "zlib"
+
+class CompressedRequests
+  def initialize(app)
+    @app = app
+  end
+
+  def encoding_handled?(env)
+    ['gzip', 'deflate'].include? env['HTTP_CONTENT_ENCODING']
+  end
+
+  def call(env)
+    if encoding_handled?(env)
+      extracted = decode(env['rack.input'], env['HTTP_CONTENT_ENCODING'])
+
+      env.delete('HTTP_CONTENT_ENCODING')
+      env['CONTENT_LENGTH'] = extracted.bytesize
+      env['rack.input'] = StringIO.new(extracted)
+    end
+
+    status, headers, response = @app.call(env)
+    return [status, headers, response]
+  end
+
+  def decode(input, content_encoding)
+    case content_encoding
+      when 'gzip' then Zlib::GzipReader.new(input).read
+      when 'deflate' then Zlib::Inflate.inflate(input.read)
+    end
+  end
+end


### PR DESCRIPTION
We are using a simple rack handling defined in the Sinatra chains that will automatically uncompressed any request with `CONTENT_ENCODING` set to gzip.

