### PR TITLE
Relax dependency on logstash-mixin-http_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.1
+  - relax dependency on logstash-mixin-http_client, to allow 4.4+ to be installed with LS 5.x
+
 ## 4.4.0
   - Adding a new option `http_compression` for sending compressed payload with the `Content-Encoding: gzip` header to the configured http endpoint #66
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '4.4.0'
+  s.version         = '4.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `PUT` or `POST` events to a generic HTTP(S) endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 5.1.0", "< 6.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'


### PR DESCRIPTION
When we have released version 4.3.0 on this plugin we have bumped the
requirements on the mixin to be 5.1.0 or higher, the problem is this
break our contract of the 5.x of the plugin. This makes our 4.3+ plugin only
installable on Logstash 5.4+.

By looking at the changelog and commits of this plugins we did 2 major
bumps.

LS 5.1 was released with the 3.x branch
LS 5.2 was released with the 4.x branch
LS 6.x is released with the 5.x branch

When I look at the changes on the mixin we have changed how we handle
SSL verification and we have added new options for basic auth.

Theses configuration are provided by the mixin and the mixin also
provide the factory for the http client.

I think we can relax the configuration and make this plugin work with
any installed mixin the draw back of this is may make the doc out of
sync with the capabilities of this plugins. This is the problem with
shared dependencies.

Related PR: #66