### PR TITLE
Add empty event array check to multi_receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.2
+  - Add check to avoid hanging pipeline if an empty event array is passed in. #80
+
 ## 5.1.1
   - Update gemspec summary
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -113,7 +113,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   end # def register
 
   def multi_receive(events)
-    send_events(events)
+    send_events(events) unless events.empty?
   end
   
   class RetryTimerTask < java.util.TimerTask
@@ -136,7 +136,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     
     pending = Queue.new
     events.each {|e| pending << [e, 0]}
-    
+
     while popped = pending.pop
       break if popped == :done
       

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.1.1'
+  s.version         = '5.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -128,6 +128,12 @@ describe LogStash::Outputs::Http do
       allow(subject).to receive(:log_failure).with(any_args)
     end
 
+    context 'sending no events' do
+      it 'should not block the pipeline' do
+        subject.multi_receive([])
+      end
+    end
+
     context "performing a get" do
       describe "invoking the request" do
         before do


### PR DESCRIPTION
Adds a check to return if #multi_receive is called with an empty array.
If this happens, the plugin will hang indefinitely on a #pop call that
will never return.

Fixes #80  