### PR TITLE
Fix high CPU on retries in json_batch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 Gemfile.lock
 .bundle
 vendor
+*.iml
 .idea
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.2
+  - Fix high CPU usage on retries in json_batch mode.
+
 ## 5.2.1
   - Docs: Set the default_codec doc attribute.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.2.2
-  - Fix high CPU usage on retries in json_batch mode.
+  - Fix high CPU usage on retries in json_batch mode. [#89](https://github.com/logstash-plugins/logstash-output-http/pull/89)
+  - Enable compression in json_batch mode. [#89](https://github.com/logstash-plugins/logstash-output-http/pull/89)
 
 ## 5.2.1
   - Docs: Set the default_codec doc attribute.

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -231,7 +231,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     headers = @is_batch ? @headers : event_headers(event)
 
     # Compress the body and add appropriate header
-    if @http_compression == true && !@is_batch
+    if @http_compression == true
       headers["Content-Encoding"] = "gzip"
       body = gzip(body)
     end

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.2.1'
+  s.version         = '5.2.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The high CPU on retries occurred because there was a separate code path for `json_batch` mode where retries were attempted in a hot loop. This PR unifies those code paths so that the proper back-off behavior is applied to retries in all modes.

Fixes #86, #88.
