### PR TITLE
Update automatic_retries description

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -86,7 +86,7 @@ output plugins.
 
 How many times should the client retry a failing URL. We highly recommend NOT setting this value
 to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
-Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+Note: if `retry_non_idempotent` is NOT set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert` 


### PR DESCRIPTION
I found that there is a conflict between description of automatic_retries and retry_non_idempotent.
automatic_retries:
if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html#plugins-outputs-http-automatic_retries

retry_non_idempotent
If automatic_retries is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
https://www.elastic.co/guide/en/logstash/current/plugins-outputs-http.html#plugins-outputs-http-retry_non_idempotent

=> It should be:
if `retry_non_idempotent` is NOT set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.