### PR TITLE
Added support for DLQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.5
+  - Added support for DLQ [#110](https://github.com/logstash-plugins/logstash-output-http/pull/110)
+
 ## 5.2.4
   - Relax dependency on http_client mixin since current major works on both
 

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -156,9 +156,9 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
               :event => event
             )
   end
-
+  
+  # To support bwc, we check if DLQ exists. otherwise we log and drop event (previous behavior)
   def write_to_dlq(url, event, response)
-    # To support bwc, we check if DLQ exists. otherwise we log and drop event (previous behavior)
     if @dlq_writer
       @dlq_writer.write(event, "Sending #{response.code} erred HTTP request to DLQ, url: #{url}, response: #{response}")
     else

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.2.4'
+  s.version         = '5.2.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -136,7 +136,7 @@ describe LogStash::Outputs::Http do
       allow(client).to receive(:send).
                          with(expected_method, url, anything).
                          and_call_original
-      allow(subject).to receive(:log_failure).with(any_args)
+      allow(subject).to receive(:log_error_response).with(any_args)
       allow(subject).to receive(:log_retryable_response).with(any_args)
       allow(subject).to receive(:write_to_dlq).with(any_args).and_call_original
     end
@@ -165,7 +165,7 @@ describe LogStash::Outputs::Http do
         end
 
         it "should not log a failure" do
-          expect(subject).not_to have_received(:log_failure).with(any_args)
+          expect(subject).not_to have_received(:log_error_response).with(any_args)
         end
       end
 
@@ -177,7 +177,7 @@ describe LogStash::Outputs::Http do
         end
 
         it "should log a failure" do
-          expect(subject).to have_received(:log_failure).with(any_args)
+          expect(subject).to have_received(:log_error_response).with(any_args)
         end
         
         it "should not be sent to dlq" do
@@ -194,7 +194,7 @@ describe LogStash::Outputs::Http do
         end
 
         it "should not log a failure" do
-          expect(subject).not_to have_received(:log_failure).with(any_args)
+          expect(subject).not_to have_received(:log_error_response).with(any_args)
         end
 
         it "should not be sent to dlq" do
@@ -216,7 +216,7 @@ describe LogStash::Outputs::Http do
         end
 
         it "should not log a failure" do 
-          expect(subject).not_to have_received(:log_failure).with(any_args)
+          expect(subject).not_to have_received(:log_error_response).with(any_args)
         end
       end
 
@@ -229,7 +229,7 @@ describe LogStash::Outputs::Http do
         end
 
         it "should not send the event to the DLQ instead, instead log" do
-          expect(subject).to have_received(:log_failure).with(any_args)
+          expect(subject).to have_received(:log_error_response).with(any_args)
         end
       end
 
@@ -264,7 +264,7 @@ describe LogStash::Outputs::Http do
     before do
       TestApp.last_request = nil
     end
-
+    
     let(:events) { [event] }
 
     describe "with a good code" do


### PR DESCRIPTION
1. Used the same logic as elasticsearch output plugin to find out if dlq is enabled or not
[execution_context? && execution_context.dlq_writer? && execution_context.dlq_writer is not a dummy writer?]

2. if dlq is enabled, send it to dlq_writer or log and drop the the events otherwise.

Fixes logstash-plugins#109

Signed-off-by: RashmiRam <rashmi.ramanathan@freshworks.com>

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
