### PR TITLE
Add log_http_payload option

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,6 +56,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-keystore_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-log_http_payload>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-mapping>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
@@ -242,6 +243,14 @@ Note, most .jks files created with keytool require a password!
   * Default value is `"JKS"`
 
 Specify the keystore type here. One of `JKS` or `PKCS12`. Default is `JKS`
+
+[id="plugins-{type}s-{plugin}-log_http_payload"]
+===== `log_http_payload`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+  
+Turn this off to avoid printing HTTP payloads into error logs.
 
 [id="plugins-{type}s-{plugin}-mapping"]
 ===== `mapping` 


### PR DESCRIPTION
This commit adds a new option to disable large HTTP payloads from being logged along with error messages.

Logging payloads that Logstash failed to send can lead to "explosions" in workflows like this:

0. Logstash is running as systemd service.
1. System journal is forwarded into Graylog.
2. Graylog filters input data and separates them into streams using patterns.
3. One of the streams is then forwarded to Logstash for further processing.
4. The Logstash instance tries to forward the data to an HTTP endpoind and fails to do so.
5. Logstash announces an error and includes the HTTP payload.
6. The error message gets into the journal and back to Graylog where it matches the stream rules again. (=> 2)

This approach is way simpler than trying to fiddle with Log4j2 regex replace in order to get rid of the `:body=>` log entry.