### PR TITLE
Fix retry indefinitely in termination process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 5.4.1
-
-- Fix retry indefinitely in termination process. This feature requires Logstash
-  8.1 [#129](https://github.com/logstash-plugins/logstash-output-http/pull/129)
-- Docs: Add retry policy description [#130](https://github.com/logstash-plugins/logstash-output-http/pull/130)
+  - Fix retry indefinitely in termination process. This feature requires Logstash 8.1 [#129](https://github.com/logstash-plugins/logstash-output-http/pull/129)
+  - Docs: Add retry policy description [#130](https://github.com/logstash-plugins/logstash-output-http/pull/130)
 
 ## 5.4.0
   - Introduce retryable unknown exceptions for "connection reset by peer" and "timeout" [#127](https://github.com/logstash-plugins/logstash-output-http/pull/127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.0
+  - Introduce retryable unknown exceptions for "connection reset by peer" and "timeout" [#127](https://github.com/logstash-plugins/logstash-output-http/pull/127)
+
 ## 5.3.0
   - Feat: support ssl_verification_mode option [#126](https://github.com/logstash-plugins/logstash-output-http/pull/126)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.1
+  - Fix retry indefinitely in termination process. This feature requires Logstash 8.1 [#129](https://github.com/logstash-plugins/logstash-output-http/pull/129)
+
 ## 5.4.0
   - Introduce retryable unknown exceptions for "connection reset by peer" and "timeout" [#127](https://github.com/logstash-plugins/logstash-output-http/pull/127)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,10 +26,10 @@ This output lets you send events to a generic HTTP(S) endpoint.
 This output will execute up to 'pool_max' requests in parallel for performance.
 Consider this when tuning this plugin for performance.
 
-Additionally, note that when parallel execution is used strict ordering of events is not guaranteed!
+Additionally, note that when parallel execution is used strict ordering of events is not
+guaranteed!
 
-Beware, this gem does not yet support codecs.
-Please use the 'format' option for now.
+Beware, this gem does not yet support codecs. Please use the 'format' option for now.
 
 [id="plugins-{type}s-{plugin}-retry_policy"]
 ==== Retry policy
@@ -39,25 +39,29 @@ This output has two levels of retry: library and plugin.
 [id="plugins-{type}s-{plugin}-library_retry"]
 ===== Library retry
 
-The library retry applies to IO related failures.
-Non retriable errors include SSL related problems, unresolvable hosts, connection issues, and OS/JVM level interruptions happening during a request.
+The library retry applies to IO related failures. 
+Non retriable errors include SSL related problems, unresolvable hosts,
+connection issues, and OS/JVM level interruptions happening during a request.
 
-The options for library retry are:
+The options for library retry are: 
 
-* <<plugins-{type}s-{plugin}-automatic_retries,`automatic_retries`>>.
+* <<plugins-{type}s-{plugin}-automatic_retries,`automatic_retries`>>. 
 Controls the number of times the plugin should retry after failures at the library level.
-* <<plugins-{type}s-{plugin}-retry_non_idempotent,`retry_non_idempotent`>>.
-When set to `false`, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+* <<plugins-{type}s-{plugin}-retry_non_idempotent,`retry_non_idempotent`>>. 
+When set to `false`, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be
+retried.
 
 [id="plugins-{type}s-{plugin}-plugin_retry"]
 ===== Plugin retry
 
-The options for plugin level retry are:
+The options for plugin level retry are: 
 
-* <<plugins-{type}s-{plugin}-retry_failed,`retry_failed`>>.
-When set to `true`, the plugin retries indefinitely for HTTP error response codes defined in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> option (429, 500, 502, 503, 504) and retryable exceptions (socket timeout/ error, DNS resolution failure and client protocol exception).
-* <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>>.
-Sets http response codes that trigger a retry.
+* <<plugins-{type}s-{plugin}-retry_failed,`retry_failed`>>. 
+When set to `true`, the plugin retries indefinitely for HTTP error response codes defined
+in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> option
+(429, 500, 502, 503, 504) and retryable exceptions (socket timeout/ error, DNS resolution failure and client protocol exception).
+* <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>>. 
+Sets http response codes that trigger a retry. 
 
 NOTE: The `retry_failed` option does not control the library level retry.
 
@@ -112,35 +116,35 @@ output plugins.
 [id="plugins-{type}s-{plugin}-automatic_retries"]
 ===== `automatic_retries` 
 
-* Value type is <<number,number>>
-* Default value is `1`
+  * Value type is <<number,number>>
+  * Default value is `1`
 
-How many times should the client retry a failing URL.
-We recommend setting this option to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepalive` option>> is enabled.
+How many times should the client retry a failing URL. We recommend setting this option
+to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepalive` option>> is enabled. 
 Some servers incorrectly end keepalives early, requiring a retry.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert` 
 
-* Value type is <<path,path>>
-* There is no default value for this setting.
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
 
 If you need to use a custom X.509 CA (.pem certs) specify the path to that here
 
 [id="plugins-{type}s-{plugin}-client_cert"]
 ===== `client_cert` 
 
-* Value type is <<path,path>>
-* There is no default value for this setting.
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
 
 If you'd like to use a client certificate (note, most people don't want this) set the path to the x509 cert here
 
 [id="plugins-{type}s-{plugin}-client_key"]
 ===== `client_key` 
 
-* Value type is <<path,path>>
-* There is no default value for this setting.
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
 
 If you're using a client certificate specify the path to the encryption key here
 
@@ -313,8 +317,8 @@ Max number of concurrent connections to a single host. Defaults to `25`
 [id="plugins-{type}s-{plugin}-proxy"]
 ===== `proxy` 
 
-* Value type is <<string,string>>
-* There is no default value for this setting.
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
 
 If you'd like to use an HTTP proxy . This supports multiple configuration syntaxes:
 
@@ -325,30 +329,32 @@ If you'd like to use an HTTP proxy . This supports multiple configuration syntax
 [id="plugins-{type}s-{plugin}-request_timeout"]
 ===== `request_timeout` 
 
-* Value type is <<number,number>>
-* Default value is `60`
+  * Value type is <<number,number>>
+  * Default value is `60`
 
-This module makes it easy to add a very fully configured HTTP client to logstash based on [Manticore](https://github.com/cheald/manticore).
+This module makes it easy to add a very fully configured HTTP client to logstash
+based on [Manticore](https://github.com/cheald/manticore).
 For an example of its usage see https://github.com/logstash-plugins/logstash-input-http_poller
 Timeout (in seconds) for the entire request
 
 [id="plugins-{type}s-{plugin}-retry_failed"]
 ===== `retry_failed` 
 
-* Value type is <<boolean,boolean>>
-* Default value is `true`
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
 
-Note that this option controls plugin-level retries only.
-It has no affect on library-level retries.
+Note that this option controls plugin-level retries only. 
+It has no affect on library-level retries. 
 
-Set this option to `false` if you want to disable infinite retries for HTTP error response codes defined in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> or retryable exceptions (Timeout, SocketException, ClientProtocolException, ResolutionFailure and SocketTimeout).
+Set this option to `false` if you want to disable infinite retries for HTTP error response codes defined in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> or 
+retryable exceptions (Timeout, SocketException, ClientProtocolException, ResolutionFailure and SocketTimeout).
 See <<plugins-{type}s-{plugin}-retry_policy,Retry policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-retry_non_idempotent"]
 ===== `retry_non_idempotent` 
 
-* Value type is <<boolean,boolean>>
-* Default value is `false`
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
 
 When this option is set to `false` and `automatic_retries` is enabled, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
@@ -358,8 +364,8 @@ See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 [id="plugins-{type}s-{plugin}-retryable_codes"]
 ===== `retryable_codes` 
 
-* Value type is <<number,number>>
-* Default value is `[429, 500, 502, 503, 504]`
+  * Value type is <<number,number>>
+  * Default value is `[429, 500, 502, 503, 504]`
 
 If the plugin encounters these response codes, the plugin will retry indefinitely.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
@@ -367,18 +373,17 @@ See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 [id="plugins-{type}s-{plugin}-socket_timeout"]
 ===== `socket_timeout` 
 
-* Value type is <<number,number>>
-* Default value is `10`
+  * Value type is <<number,number>>
+  * Default value is `10`
 
-Timeout (in seconds) to wait for data on the socket.
-Default is `10s`
+Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 [id="plugins-{type}s-{plugin}-ssl_verification_mode"]
 ===== `ssl_verification_mode`
 
-* Value type is <<string,string>>
-* Supported values are: `full`, `none`
-* Default value is `full`
+  * Value type is <<string,string>>
+  * Supported values are: `full`, `none`
+  * Default value is `full`
 
 Controls the verification of server certificates.
 The `full` option verifies that the provided certificate is signed by a trusted authority (CA)

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -181,7 +181,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
       event, attempt = popped
 
       raise PluginInternalQueueLeftoverError.new("Received pipeline shutdown request but http output has unfinished events. " \
-              "If persistent queue is enabled, events will be retried.") if shutdown_requested && attempt > 2
+              "If persistent queue is enabled, events will be retried.") if pipeline_shutdown_requested? && attempt > 2
 
       action, event, attempt = send_event(event, attempt)
       begin
@@ -227,8 +227,9 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     raise e
   end
 
-  def shutdown_requested
-    execution_context.pipeline.respond_to?(:shutdown_requested) && execution_context.pipeline.shutdown_requested
+  def pipeline_shutdown_requested?
+    return super if defined?(super) # since LS 8.1.0
+    nil
   end
 
   def sleep_for_attempt(attempt)

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -28,6 +28,7 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
     /Read Timed out/i
   ]
 
+  class PluginInternalQueueLeftoverError < StandardError; end
 
   # This output lets you send events to a
   # generic HTTP(S) endpoint
@@ -179,6 +180,9 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
       event, attempt = popped
 
+      raise PluginInternalQueueLeftoverError.new("Received pipeline shutdown request but http output has unfinished events. " \
+              "If persistent queue is enabled, events will be retried.") if shutdown_requested && attempt > 2
+
       action, event, attempt = send_event(event, attempt)
       begin
         action = :failure if action == :retry && !@retry_failed
@@ -221,6 +225,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
             :message => e.message,
             :backtrace => e.backtrace)
     raise e
+  end
+
+  def shutdown_requested
+    execution_context.pipeline.respond_to?(:shutdown_requested) && execution_context.pipeline.shutdown_requested
   end
 
   def sleep_for_attempt(attempt)

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.4.0'
+  s.version         = '5.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.3.0'
+  s.version         = '5.4.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -501,6 +501,23 @@ describe LogStash::Outputs::Http do
       let(:base_config) { { "http_compression" => true } }
     end
   end
+
+  describe "retryable error in termination" do
+    let(:url) { "http://localhost:#{port-1}/invalid" }
+    let(:events) { [event] }
+    let(:config) { {"url" => url, "http_method" => "get", "pool_max" => 1} }
+
+    subject { LogStash::Outputs::Http.new(config) }
+
+    before do
+      subject.register
+      allow(subject).to receive(:shutdown_requested).and_return(true)
+    end
+
+    it "raise exception to exit indefinitely retry" do
+      expect { subject.multi_receive(events) }.to raise_error(LogStash::Outputs::Http::PluginInternalQueueLeftoverError)
+    end
+  end
 end
 
 describe LogStash::Outputs::Http do # different block as we're starting web server with TLS

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -511,7 +511,7 @@ describe LogStash::Outputs::Http do
 
     before do
       subject.register
-      allow(subject).to receive(:shutdown_requested).and_return(true)
+      allow(subject).to receive(:pipeline_shutdown_requested?).and_return(true)
     end
 
     it "raise exception to exit indefinitely retry" do


### PR DESCRIPTION
The plugin is blocking the shutdown process when `url` point to an invalid port, which is a retryable error that retry indefinitely

This commit adds a checking that checks pipeline shutdown state to quit retry loop
This feature requires logstash-core that exposes shutdown_requested https://github.com/elastic/logstash/pull/13811

Fixed: #123
