### PR TITLE
[Doc] clarify retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.1
+  - Docs: Add retry policy description [#130](https://github.com/logstash-plugins/logstash-output-http/pull/130) 
+
 ## 5.4.0
   - Introduce retryable unknown exceptions for "connection reset by peer" and "timeout" [#127](https://github.com/logstash-plugins/logstash-output-http/pull/127)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -120,7 +120,7 @@ output plugins.
   * Value type is <<number,number>>
   * Default value is `1`
 
-How many times should the client retry a failing URL. We highly recommend NOT setting this value
+How many times should the client retry a failing URL. We recommend setting this option
 to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -343,8 +343,11 @@ Timeout (in seconds) for the entire request
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-Set this to false if you don't want this output to retry plugin level failed requests.
-See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
+Note that this option controls retries for plugin-level requests only. 
+It has no affect on library-level retries. 
+
+Set this option to `false` if you want to disable retries on failed plugin-level requests.
+See <<plugins-{type}s-{plugin}-retry_policy,Retry policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-retry_non_idempotent"]
 ===== `retry_non_idempotent` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -57,10 +57,9 @@ retried.
 The options for plugin level retry are: 
 
 * <<plugins-{type}s-{plugin}-retry_failed,`retry_failed`>>. 
-When set to `true`, the plugin retries indefinitely for HTTP responses defined
+When set to `true`, the plugin retries indefinitely for HTTP error response codes defined
 in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> option
-(429, 500, 502, 503, 504) and retryable exceptions (Timeout, SocketException,
-ClientProtocolException, ResolutionFailure and SocketTimeout).
+(429, 500, 502, 503, 504) and retryable exceptions (socket timeout/ error, DNS resolution failure and client protocol exception).
 * <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>>. 
 Sets http response codes that trigger a retry. 
 
@@ -121,7 +120,8 @@ output plugins.
   * Default value is `1`
 
 How many times should the client retry a failing URL. We recommend setting this option
-to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepalive` option>> is enabled. Some servers incorrectly end keepalives early, requiring a retry.
+to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepalive` option>> is enabled. 
+Some servers incorrectly end keepalives early, requiring a retry.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-cacert"]
@@ -343,10 +343,11 @@ Timeout (in seconds) for the entire request
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-Note that this option controls retries for plugin-level requests only. 
+Note that this option controls plugin-level retries only. 
 It has no affect on library-level retries. 
 
-Set this option to `false` if you want to disable retries on failed plugin-level requests.
+Set this option to `false` if you want to disable infinite retries for HTTP error response codes defined in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> or 
+retryable exceptions (Timeout, SocketException, ClientProtocolException, ResolutionFailure and SocketTimeout).
 See <<plugins-{type}s-{plugin}-retry_policy,Retry policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-retry_non_idempotent"]
@@ -355,8 +356,10 @@ See <<plugins-{type}s-{plugin}-retry_policy,Retry policy>> for more information.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
-This only affects connectivity related errors (see related `automatic_retries` setting).
+When set to `false` and `automatic_retries` is enabled, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+
+When set to `true` and `automatic_retries` is enabled, this will cause non-idempotent HTTP verbs (such as POST) to be retried.
+See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-retryable_codes"]
 ===== `retryable_codes` 
@@ -364,7 +367,8 @@ This only affects connectivity related errors (see related `automatic_retries` s
   * Value type is <<number,number>>
   * Default value is `[429, 500, 502, 503, 504]`
 
-If encountered as response codes this plugin will retry these requests
+If encountered these response codes, the plugin will retry indefinitely
+See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-socket_timeout"]
 ===== `socket_timeout` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -46,7 +46,7 @@ connection issues, and OS/JVM level interruptions happening during a request.
 The options for library retry are: 
 
 * <<plugins-{type}s-{plugin}-automatic_retries,`automatic_retries`>>. 
-Controls the number of times of retry in the library level.
+Controls the number of times the plugin should retry after failures at the library level.
 * <<plugins-{type}s-{plugin}-retry_non_idempotent,`retry_non_idempotent`>>. 
 When set to `false`, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be
 retried.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,7 @@ Beware, this gem does not yet support codecs. Please use the 'format' option for
 [id="plugins-{type}s-{plugin}-retry_policy"]
 ==== Retry policy
 
-This output has two levels of retry, library and plugin.
+This output has two levels of retry: library and plugin.
 
 The library only retry IO related failures. Non retriable errors include SSL related problems, unresolvable host, connection issues and OS/JVM level interruptions happening during a request.
 `automatic_retries`, `retry_non_idempotent` are the flags for library retry.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -367,7 +367,7 @@ See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
   * Value type is <<number,number>>
   * Default value is `[429, 500, 502, 503, 504]`
 
-If encountered these response codes, the plugin will retry indefinitely
+If the plugin encounters these response codes, the plugin will retry indefinitely.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-socket_timeout"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,7 +36,7 @@ Beware, this gem does not yet support codecs. Please use the 'format' option for
 
 This output has two levels of retry, library and plugin.
 
-The library only retry IO related failures. Non retriable IOException are InterruptedIOException, UnknownHostException, ConnectException and SSLException.
+The library only retry IO related failures. Non retriable errors include SSL related problems, unresolvable host, connection issues and OS/JVM level interruptions happening during a request.
 `automatic_retries`, `retry_non_idempotent` are the flags for library retry.
 `automatic_retries` controls the number of times of retry in the library level.
 `retry_non_idempotent` set to `false` means GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,13 +36,16 @@ Beware, this gem does not yet support codecs. Please use the 'format' option for
 
 This output has two levels of retry, library and plugin.
 
-The library only retry IO related failures. Non retriable IOException include InterruptedIOException, UnknownHostException, ConnectException and SSLException.
+The library only retry IO related failures. Non retriable IOException are InterruptedIOException, UnknownHostException, ConnectException and SSLException.
 `automatic_retries`, `retry_non_idempotent` are the flags for library retry.
 `automatic_retries` controls the number of times of retry in the library level.
 `retry_non_idempotent` set to `false` means GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
 The plugin level retry has two flags `retry_failed` and `retryable_codes`.
+`retry_failed` retry indefinitely for HTTP responses defining in `retryable_codes` (429, 500, 502, 503, 504)
+and retryable exceptions (Timeout, SocketException, ClientProtocolException, ResolutionFailure and SocketTimeout)
 
+NOTE: `retry_failed` does not control the library level retry.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http Output Configuration Options
@@ -99,11 +102,8 @@ output plugins.
   * Default value is `1`
 
 How many times should the client retry a failing URL. We highly recommend NOT setting this value
-to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
-Only IO related failures will be retried, such as connection timeouts and unreachable hosts.
-Valid but non 2xx HTTP responses will always be retried, regardless of the value of this setting,
-unless `retry_failed` is set.
-Note: if `retry_non_idempotent` is NOT set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry.
+See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-cacert"]
 ===== `cacert` 
@@ -324,7 +324,8 @@ Timeout (in seconds) for the entire request
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
-Set this to false if you don't want this output to retry failed requests
+Set this to false if you don't want this output to retry plugin level failed requests.
+See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-retry_non_idempotent"]
 ===== `retry_non_idempotent` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -356,7 +356,7 @@ See <<plugins-{type}s-{plugin}-retry_policy,Retry policy>> for more information.
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
-When set to `false` and `automatic_retries` is enabled, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+When this option is set to `false` and `automatic_retries` is enabled, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
 
 When set to `true` and `automatic_retries` is enabled, this will cause non-idempotent HTTP verbs (such as POST) to be retried.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,16 +36,35 @@ Beware, this gem does not yet support codecs. Please use the 'format' option for
 
 This output has two levels of retry: library and plugin.
 
-The library only retry IO related failures. Non retriable errors include SSL related problems, unresolvable host, connection issues and OS/JVM level interruptions happening during a request.
-`automatic_retries`, `retry_non_idempotent` are the flags for library retry.
-`automatic_retries` controls the number of times of retry in the library level.
-`retry_non_idempotent` set to `false` means GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+[id="plugins-{type}s-{plugin}-library_retry"]
+===== Library retry
 
-The plugin level retry has two flags `retry_failed` and `retryable_codes`.
-`retry_failed` retry indefinitely for HTTP responses defining in `retryable_codes` (429, 500, 502, 503, 504)
-and retryable exceptions (Timeout, SocketException, ClientProtocolException, ResolutionFailure and SocketTimeout)
+The library retry applies to IO related failures. 
+Non retriable errors include SSL related problems, unresolvable hosts,
+connection issues, and OS/JVM level interruptions happening during a request.
 
-NOTE: `retry_failed` does not control the library level retry.
+The options for library retry are: 
+
+* <<plugins-{type}s-{plugin}-automatic_retries,`automatic_retries`>>. 
+Controls the number of times of retry in the library level.
+* <<plugins-{type}s-{plugin}-retry_non_idempotent,`retry_non_idempotent`>>. 
+When set to `false`, GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be
+retried.
+
+[id="plugins-{type}s-{plugin}-plugin_retry"]
+===== Plugin retry
+
+The options for plugin level retry are: 
+
+* <<plugins-{type}s-{plugin}-retry_failed,`retry_failed`>>. 
+When set to `true`, the plugin retries indefinitely for HTTP responses defined
+in the <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>> option
+(429, 500, 502, 503, 504) and retryable exceptions (Timeout, SocketException,
+ClientProtocolException, ResolutionFailure and SocketTimeout).
+* <<plugins-{type}s-{plugin}-retryable_codes,`retryable_codes`>>. 
+Sets http response codes that trigger a retry. 
+
+NOTE: The `retry_failed` option does not control the library level retry.
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http Output Configuration Options

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -121,7 +121,7 @@ output plugins.
   * Default value is `1`
 
 How many times should the client retry a failing URL. We recommend setting this option
-to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry.
+to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepalive` option>> is enabled. Some servers incorrectly end keepalives early, requiring a retry.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
 [id="plugins-{type}s-{plugin}-cacert"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,6 +31,19 @@ guaranteed!
 
 Beware, this gem does not yet support codecs. Please use the 'format' option for now.
 
+[id="plugins-{type}s-{plugin}-retry_policy"]
+==== Retry policy
+
+This output has two levels of retry, library and plugin.
+
+The library only retry IO related failures. Non retriable IOException include InterruptedIOException, UnknownHostException, ConnectException and SSLException.
+`automatic_retries`, `retry_non_idempotent` are the flags for library retry.
+`automatic_retries` controls the number of times of retry in the library level.
+`retry_non_idempotent` set to `false` means GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+
+The plugin level retry has two flags `retry_failed` and `retryable_codes`.
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http Output Configuration Options
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.4.0'
+  s.version         = '5.4.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The retry policy confuses users mainly due to the unclear boundary of `retry_failed` and `automatic_retries`.

This PR explains `retry_failed` set to `false` does not affect the number of retries in lib level