### PR TITLE
add response body logging to non 2xx responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.6.1
-  - Added body and event logging in debug level for non 2xx responses
+  - Added body and event logging in debug level for non 2xx responses [#142](https://github.com/logstash-plugins/logstash-output-http/pull/142)
 
 ## 5.6.0
   - Added standardized SSL settings and deprecates their non-standard counterparts. Deprecated settings will continue to work, and will provide pipeline maintainers with guidance toward using their standardized counterparts [#140](https://github.com/logstash-plugins/logstash-output-http/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.6.1
-  - Added body and event logging in debug level for non 2xx responses [#142](https://github.com/logstash-plugins/logstash-output-http/pull/142)
+  - Added body logging for non 2xx responses [#142](https://github.com/logstash-plugins/logstash-output-http/pull/142)
 
 ## 5.6.0
   - Added standardized SSL settings and deprecates their non-standard counterparts. Deprecated settings will continue to work, and will provide pipeline maintainers with guidance toward using their standardized counterparts [#140](https://github.com/logstash-plugins/logstash-output-http/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.1
+  - Added body and event logging in debug level for non 2xx responses
+
 ## 5.6.0
   - Added standardized SSL settings and deprecates their non-standard counterparts. Deprecated settings will continue to work, and will provide pipeline maintainers with guidance toward using their standardized counterparts [#140](https://github.com/logstash-plugins/logstash-output-http/pull/140)
   - Added new `ssl_truststore_path`, `ssl_truststore_password`, and `ssl_truststore_type` settings for configuring SSL-trust using a PKCS-12 or JKS trust store, deprecating their `truststore`, `truststore_password`, and `truststore_type` counterparts.

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -154,12 +154,15 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
   end
 
   def log_error_response(response, url, event)
-    log_failure(
-              "Encountered non-2xx HTTP code #{response.code}",
-              :response_code => response.code,
-              :url => url,
-              :event => event
-            )
+    log_details = {
+      :response_code => response.code,
+      :url => url,
+    }
+    if @logger.debug?
+      log_details[:event] = event.to_json
+      log_details[:response_body] = response.body
+    end
+    log_failure("Encountered non-2xx HTTP code", log_details)
   end
 
   def send_events(events)

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -155,13 +155,10 @@ class LogStash::Outputs::Http < LogStash::Outputs::Base
 
   def log_error_response(response, url, event)
     log_details = {
-      :response_code => response.code,
+      :code => response.code,
+      :body => response.body,
       :url => url,
     }
-    if @logger.debug?
-      log_details[:event] = event.to_json
-      log_details[:response_body] = response.body
-    end
     log_failure("Encountered non-2xx HTTP code", log_details)
   end
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.6.0'
+  s.version         = '5.6.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Log the response body ~~and the event (in JSON format)~~ when the endpoint returns a non 2xx response.

Before, the logging entry included `:event => event`, but the event wasn't being displayed at all, it was just an stringified object reference. ~~Given the potential size of the event or response size, both of these are only logged in debug mode.~~
This PR makes logging more consistent with the retryable error logging.