### PR TITLE
Add ssl_enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.7.0
+  - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#143](https://github.com/logstash-plugins/logstash-output-http/pull/143)
+
 ## 5.6.1
   - Added body logging for non 2xx responses [#142](https://github.com/logstash-plugins/logstash-output-http/pull/142)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -103,6 +103,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of <<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_type>> |<<string,string>>|No
@@ -419,6 +420,15 @@ The .cer or .pem CA files to validate the server's certificate.
 
 The list of cipher suites to use, listed by priorities.
 Supported cipher suites vary depending on the Java and protocol versions.
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Enable SSL/TLS secured communication. It must be `true` for other `ssl_` options
+to take effect.
 
 [id="plugins-{type}s-{plugin}-ssl_key"]
 ===== `ssl_key`

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.6.1'
+  s.version         = '5.7.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.3.0", "< 8.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.4.0", "< 8.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -304,7 +304,7 @@ describe LogStash::Outputs::Http do
       let(:config) {
         base_config.merge({"url" => url, "http_method" => "post", "pool_max" => 1})
       }
-      let(:expected_body) { LogStash::Json.dump(event) }
+      let(:expected_body) { event.to_json }
       let(:expected_content_type) { "application/json" }
 
       include_examples("a received event")


### PR DESCRIPTION
Added support to the `ssl_enabled` option by bumping the `logstash-mixin-http_client` ([logstash-mixin-http_client/pull/44](https://github.com/logstash-plugins/logstash-mixin-http_client/pull/44)), making it compliant with the [Logstash SSL Standardisation](https://github.com/elastic/logstash/issues/14905).

---
Closes: https://github.com/logstash-plugins/logstash-output-http/issues/143