### PR TITLE
Mark deprecated SSL settings as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 6.0.0
+  - SSL settings that were marked deprecated in version `5.6.0` are now marked obsolete, and will prevent the plugin from starting.
+  - These settings are:   
+  - `cacert`, which should be replaced by `ssl_certificate_authorities`
+  - `client_cert`, which should be replaced by `ssl_certificate`
+  - `client_key`, which should be replaced by `ssl_key`
+  - `keystore`, which should be replaced by `ssl_keystore_path`
+  - `keystore_password`, which should be replaced by `ssl_keystore_password`
+  - `keystore_type`, which should be replaced by `ssl_keystore_password`
+  - `truststore`, which should be replaced by `ssl_truststore_path>`
+  - `truststore_password`, which should be replaced by `ssl_truststore_password`
+  - `truststore_type`, which should be replaced by `ssl_truststore_type`
+  - [#147](https://github.com/logstash-plugins/logstash-output-http/pull/147)
+
 ## 5.7.1
   - Added new development `rackup` dependency to fix tests 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,13 +70,13 @@ NOTE: The `retry_failed` option does not control the library level retry.
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
+NOTE: As of version 6.0 of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
+<<plugins-{type}s-{plugin}-obsolete-options>> for more details.
+
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-automatic_retries>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-client_cert>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-client_key>> |a valid filesystem path|__Deprecated__
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-content_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
@@ -87,9 +87,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-http_method>> |<<string,string>>, one of `["put", "post", "patch", "delete", "get", "head"]`|Yes
 | <<plugins-{type}s-{plugin}-ignorable_codes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|__Deprecated__
-| <<plugins-{type}s-{plugin}-keystore_type>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-mapping>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
@@ -112,9 +109,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_truststore_path>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_truststore_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
-| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|__Deprecated__
-| <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-url>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-validate_after_inactivity>> |<<number,number>>|No
 |=======================================================================
@@ -135,32 +129,6 @@ to a value other than zero if the <<plugins-{type}s-{plugin}-keepalive,`keepaliv
 Some servers incorrectly end keepalives early, requiring a retry.
 See <<plugins-{type}s-{plugin}-retry_policy,Retry Policy>> for more information.
 
-[id="plugins-{type}s-{plugin}-cacert"]
-===== `cacert` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom X.509 CA (.pem certs) specify the path to that here
-
-[id="plugins-{type}s-{plugin}-client_cert"]
-===== `client_cert` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you'd like to use a client certificate (note, most people don't want this) set the path to the x509 cert here
-
-[id="plugins-{type}s-{plugin}-client_key"]
-===== `client_key` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_key>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you're using a client certificate specify the path to the encryption key here
 
 [id="plugins-{type}s-{plugin}-connect_timeout"]
 ===== `connect_timeout` 
@@ -264,34 +232,6 @@ enumerate them here. Responses returning these codes will be considered successe
 
 Turn this on to enable HTTP keepalive support. We highly recommend setting `automatic_retries` to at least
 one with this to fix interactions with broken keepalive implementations.
-
-[id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom keystore (`.jks`) specify that here. This does not work with .pem keys!
-
-[id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Specify the keystore password here.
-Note, most .jks files created with keytool require a password!
-
-[id="plugins-{type}s-{plugin}-keystore_type"]
-===== `keystore_type`
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_type>>]
-
-  * Value type is <<string,string>>
-  * Default value is `"JKS"`
-
-Specify the keystore type here. One of `JKS` or `PKCS12`. Default is `JKS`
 
 [id="plugins-{type}s-{plugin}-mapping"]
 ===== `mapping` 
@@ -523,34 +463,6 @@ This mode disables many of the security benefits of SSL/TLS and should only be u
 It is primarily intended as a temporary diagnostic mechanism when attempting to resolve TLS errors.
 Using `none`  in production environments is strongly discouraged.
 
-[id="plugins-{type}s-{plugin}-truststore"]
-===== `truststore` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom truststore (`.jks`) specify that here. This does not work with .pem certs!
-
-[id="plugins-{type}s-{plugin}-truststore_password"]
-===== `truststore_password` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Specify the truststore password here.
-Note, most .jks files created with keytool require a password!
-
-[id="plugins-{type}s-{plugin}-truststore_type"]
-===== `truststore_type` 
-deprecated[5.6.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_type>>]
-
-  * Value type is <<string,string>>
-  * Default value is `"JKS"`
-
-Specify the truststore type here. One of `JKS` or `PKCS12`. Default is `JKS`
-
 [id="plugins-{type}s-{plugin}-url"]
 ===== `url` 
 
@@ -572,6 +484,27 @@ Quoting the Apache commons docs (this client is based Apache Commmons):
 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
 See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
 
+
+[id="plugins-{type}s-{plugin}-obsolete-options"]
+==== HTTP Output Obsolete Configuration Options
+
+WARNING: As of version `6.0` of this plugin, the following configuration options are no longer available,
+and have been replaced by the following options:
+
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cacert |<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| client_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
+| client_key |<<plugins-{type}s-{plugin}-ssl_key>>
+| keystore |<<plugins-{type}s-{plugin}-ssl_keystore_path>>
+| keystore_password |<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| keystore_type |<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| truststore |<<plugins-{type}s-{plugin}-ssl_truststore_path>>
+| truststore_password |<<plugins-{type}s-{plugin}-ssl_truststore_password>>
+| truststore_type |<<plugins-{type}s-{plugin}-ssl_truststore_type>>
+|=======================================================================
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,7 +70,7 @@ NOTE: The `retry_failed` option does not control the library level retry.
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
-NOTE: As of version 6.0 of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
+NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
 <<plugins-{type}s-{plugin}-obsolete-options>> for more details.
 
 [cols="<,<,<",options="header",]
@@ -488,7 +488,7 @@ See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache
 [id="plugins-{type}s-{plugin}-obsolete-options"]
 ==== HTTP Output Obsolete Configuration Options
 
-WARNING: As of version `6.0` of this plugin, the following configuration options are no longer available,
+WARNING: As of version `6.0.0` of this plugin, the following configuration options are no longer available,
 and have been replaced by the following options:
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,8 +70,8 @@ NOTE: The `retry_failed` option does not control the library level retry.
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
-NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. Please see the
-<<plugins-{type}s-{plugin}-obsolete-options>> for more details.
+NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed. 
+Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -488,8 +488,8 @@ See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache
 [id="plugins-{type}s-{plugin}-obsolete-options"]
 ==== HTTP Output Obsolete Configuration Options
 
-WARNING: As of version `6.0.0` of this plugin, the following configuration options are no longer available,
-and have been replaced by the following options:
+WARNING: As of version `6.0.0` of this plugin, some configuration options have been replaced.
+The plugin will fail to start if it contains any of these obsolete options. 
 
 
 [cols="<,<",options="header",]

--- a/lib/logstash/outputs/http.rb
+++ b/lib/logstash/outputs/http.rb
@@ -7,7 +7,7 @@ require "logstash/plugin_mixins/http_client"
 require "zlib"
 
 class LogStash::Outputs::Http < LogStash::Outputs::Base
-  include LogStash::PluginMixins::HttpClient[:with_deprecated => true]
+  include LogStash::PluginMixins::HttpClient[:with_obsolete => true]
 
   concurrency :shared
 

--- a/logstash-output-http.gemspec
+++ b/logstash-output-http.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-http'
-  s.version         = '5.7.1'
+  s.version         = '6.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a generic HTTP or HTTPS endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.4.0", "< 8.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.5.0", "< 8.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'

--- a/spec/outputs/http_spec.rb
+++ b/spec/outputs/http_spec.rb
@@ -20,6 +20,32 @@ describe LogStash::Outputs::Http do
   let(:url) { "http://localhost:#{port}/good" }
   let(:method) { "post" }
 
+  describe "obsolete settings" do
+    let(:config) { {"url" => url, "http_method" => "post"} }
+
+    [{:name => 'cacert', :canonical_name => 'ssl_certificate_authorities'},
+     {:name => 'client_cert', :canonical_name => 'ssl_certificate'},
+     {:name => 'client_key', :canonical_name => 'ssl_key'},
+     {:name => "keystore", :canonical_name => 'ssl_keystore_path'},
+     {:name => 'truststore', :canonical_name => 'ssl_truststore_path'},
+     {:name => "keystore_password", :canonical_name => "ssl_keystore_password"},
+     {:name => 'truststore_password', :canonical_name => "ssl_truststore_password"},
+     {:name => "keystore_type", :canonical_name => "ssl_keystore_type"},
+     {:name => 'truststore_type', :canonical_name => 'ssl_truststore_type'}
+    ].each do |settings|
+      context "with option #{settings[:name]}" do
+        let(:obsolete_config) { config.merge(settings[:name] => 'test_value') }
+
+        it "emits an error about the setting `#{settings[:name]}` now being obsolete and provides guidance to use `#{settings[:canonical_name]}`" do
+          error_text = /The setting `#{settings[:name]}` in plugin `http` is obsolete and is no longer available. Use `#{settings[:canonical_name]}` instead/i
+          expect { LogStash::Outputs::Http.new(obsolete_config) }.to raise_error LogStash::ConfigurationError, error_text
+        end
+
+      end
+    end
+  end
+
+
   shared_examples("verb behavior") do |method|
 
     shared_examples("failure log behaviour") do


### PR DESCRIPTION
This commit marks the following SSL settings as obsolete:

'cacert', 'client_cert', 'client_key', 'keystore', 'truststore',
'keystore_password', 'truststore_password', 'keystore_type' and
'truststore_type'.
