### PR TITLE
fix [docs]: Broken link to Apache docs

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -482,7 +482,7 @@ How long to wait before checking if the connection is stale before executing a r
 You may want to set this lower, possibly to 0 if you get connection errors regularly
 Quoting the Apache commons docs (this client is based Apache Commmons):
 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
-See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+See https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
 
 
 [id="plugins-{type}s-{plugin}-obsolete-options"]


### PR DESCRIPTION
The [link to the Apache Commons http client docs](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)) is broken. 

I have replaced it with what I believe to be the correct link.
