### PR TITLE
Docs: clarify that `ssl_certificate_authorities` takes at-most-one value

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -348,9 +348,12 @@ NOTE: This setting can be used only if <<plugins-{type}s-{plugin}-ssl_key>> is s
 ===== `ssl_certificate_authorities`
 
   * Value type is a list of <<path,path>>
+  * This plugin does not support multiple entries
   * There is no default value for this setting
 
 The .cer or .pem CA files to validate the server's certificate.
+
+NOTE: When provided with a single PEM file that contains multiple certificates, all enclosed certificates will be trusted.
 
 [id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
 ===== `ssl_cipher_suites`


### PR DESCRIPTION
The `ssl_certificate_authorities` takes a list of files for purposes of the [SSL/TLS Settings Standardization](https://github.com/elastic/logstash/issues/14905) effort, but does not accept more than one _entry_ in the list:

`LogStash::ConfigurationError: Multiple values on 'ssl_certificate_authorities are not supported by this plugin`

Clarify this in docs.