### PR TITLE
Update index.asciidoc

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -91,7 +91,7 @@ Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
 | <<plugins-{type}s-{plugin}-message>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-pool_max_per_route>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-proxy>> |<<,>>|No
+| <<plugins-{type}s-{plugin}-proxy>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_failed>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No


### PR DESCRIPTION
Fix typo, this is declared a string later in the [documentation.](https://github.com/logstash-plugins/logstash-output-http/blob/a59fad7c4d94a902508d69acdf7d090594ed1941/docs/index.asciidoc?plain=1#L277) 

